### PR TITLE
Restrict Superdesign model options to GPT-5 and Gemini 2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,13 +208,13 @@
             "openrouter",
             "claude-code"
           ],
-          "default": "anthropic",
+          "default": "openai",
           "description": "AI model provider for custom agent (OpenAI, Anthropic, OpenRouter, or Claude Code - Note: Claude Code should be used via the main LLM Provider setting instead)",
           "scope": "application"
         },
         "superdesign.aiModel": {
           "type": "string",
-          "description": "Specific AI model to use (e.g., gpt-4o, claude-3-5-sonnet-20241022)",
+          "description": "Specific AI model to use (e.g., gpt-5, google/gemini-2.5-pro)",
           "scope": "application"
         }
       }

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -97,21 +97,21 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
 
     private async handleGetCurrentProvider(webview: vscode.Webview) {
         const config = vscode.workspace.getConfiguration('superdesign');
-        const currentProvider = config.get<string>('aiModelProvider', 'anthropic');
+        const currentProvider = config.get<string>('aiModelProvider', 'openai');
         const currentModel = config.get<string>('aiModel');
         
         // If no specific model is set, use defaults
         let defaultModel: string;
         switch (currentProvider) {
             case 'openai':
-                defaultModel = 'gpt-4o';
+                defaultModel = 'gpt-5';
                 break;
             case 'openrouter':
-                defaultModel = 'anthropic/claude-3-7-sonnet-20250219';
+                defaultModel = 'google/gemini-2.5-pro';
                 break;
             case 'anthropic':
             default:
-                defaultModel = 'claude-3-5-sonnet-20241022';
+                defaultModel = 'gpt-5';
                 break;
         }
         
@@ -133,7 +133,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             let displayName: string;
             
             if (model.includes('/')) {
-                // OpenRouter model (contains slash like "openai/gpt-4o")
+                // OpenRouter model (contains slash like "google/gemini-2.5-pro")
                 provider = 'openrouter';
                 apiKeyKey = 'openrouterApiKey';
                 configureCommand = 'superdesign.configureOpenRouterApiKey';
@@ -184,160 +184,13 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
     private getModelDisplayName(model: string): string {
         const modelNames: { [key: string]: string } = {
             // OpenAI models
-            'gpt-4.1': 'GPT-4.1',
-            'gpt-4.1-mini': 'GPT-4.1 Mini',
-            'gpt-4.1-nano': 'GPT-4.1 Nano',
-            'gpt-4o': 'GPT-4o',
-            'gpt-4o-mini': 'GPT-4o Mini',
-            // Anthropic models
-            'claude-4-opus-20250514': 'Claude 4 Opus',
-            'claude-4-sonnet-20250514': 'Claude 4 Sonnet',
-            'claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet',
-            'anthropic/claude-sonnet-4': 'Claude Sonnet 4',
-            'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
-            'claude-3-opus-20240229': 'Claude 3 Opus',
-            'claude-3-sonnet-20240229': 'Claude 3 Sonnet',
-            'claude-3-haiku-20240307': 'Claude 3 Haiku',
+            'gpt-5': 'GPT-5',
+            'gpt-5-mini': 'GPT-5 Mini',
             // OpenRouter - Google models
             'google/gemini-2.5-pro': 'Gemini 2.5 Pro',
-            'google/gemini-2.5-flash': 'Gemini 2.5 Flash',
-            'google/gemini-2.5-pro-preview-06-05': 'Gemini 2.5 Pro Preview',
-            'google/gemini-2.5-flash-preview-05-20': 'Gemini 2.5 Flash Preview',
-            'google/gemini-2.5-pro-preview-03-25': 'Gemini 2.5 Pro Preview (Mar)',
-            'google/gemini-2.0-flash-001': 'Gemini 2.0 Flash',
-            'google/gemini-2.0-flash-exp': 'Gemini 2.0 Flash Exp',
-            'google/gemini-2.0-flash-lite-001': 'Gemini 2.0 Flash Lite',
-            'google/gemma-3-27b-it': 'Gemma 3 27B',
-            'google/gemma-3-12b-it': 'Gemma 3 12B',
-            'google/gemma-3-4b-it': 'Gemma 3 4B',
-            'google/gemma-2-27b-it': 'Gemma 2 27B',
-            'google/gemma-2-9b-it': 'Gemma 2 9B',
-            'google/gemini-flash-1.5': 'Gemini Flash 1.5',
-            'google/gemini-flash-1.5-8b': 'Gemini Flash 1.5 8B',
-            'google/gemini-pro-1.5': 'Gemini Pro 1.5',
-            // OpenRouter - Meta models
-            'meta-llama/llama-4-maverick-17b-128e-instruct': 'Llama 4 Maverick 17B',
-            'meta-llama/llama-4-scout-17b-16e-instruct': 'Llama 4 Scout 17B',
-            'meta-llama/llama-3.3-70b-instruct': 'Llama 3.3 70B',
-            'meta-llama/llama-3.2-90b-vision-instruct': 'Llama 3.2 90B Vision',
-            'meta-llama/llama-3.2-11b-vision-instruct': 'Llama 3.2 11B Vision',
-            'meta-llama/llama-3.2-3b-instruct': 'Llama 3.2 3B',
-            'meta-llama/llama-3.2-1b-instruct': 'Llama 3.2 1B',
-            'meta-llama/llama-3.1-405b-instruct': 'Llama 3.1 405B',
-            'meta-llama/llama-3.1-70b-instruct': 'Llama 3.1 70B',
-            'meta-llama/llama-3.1-8b-instruct': 'Llama 3.1 8B',
-            'meta-llama/llama-3-70b-instruct': 'Llama 3 70B',
-            'meta-llama/llama-3-8b-instruct': 'Llama 3 8B',
-            'meta-llama/llama-guard-4-12b': 'Llama Guard 4 12B',
-            'meta-llama/llama-guard-3-8b': 'Llama Guard 3 8B',
-            'meta-llama/llama-guard-2-8b': 'Llama Guard 2 8B',
-            // OpenRouter - DeepSeek models
-            'deepseek/deepseek-r1': 'DeepSeek R1',
-            'deepseek/deepseek-r1-0528': 'DeepSeek R1 0528',
-            'deepseek/deepseek-r1-distill-llama-70b': 'DeepSeek R1 Distill Llama 70B',
-            'deepseek/deepseek-r1-distill-llama-8b': 'DeepSeek R1 Distill Llama 8B',
-            'deepseek/deepseek-r1-distill-qwen-32b': 'DeepSeek R1 Distill Qwen 32B',
-            'deepseek/deepseek-r1-distill-qwen-14b': 'DeepSeek R1 Distill Qwen 14B',
-            'deepseek/deepseek-r1-distill-qwen-7b': 'DeepSeek R1 Distill Qwen 7B',
-            'deepseek/deepseek-r1-distill-qwen-1.5b': 'DeepSeek R1 Distill Qwen 1.5B',
-            'deepseek/deepseek-chat-v3': 'DeepSeek Chat V3',
-            'deepseek/deepseek-chat-v3.1:free': 'DeepSeek Chat V3.1 Free',
-            'deepseek/deepseek-v3-base': 'DeepSeek V3 Base',
-            'deepseek/deepseek-prover-v2': 'DeepSeek Prover V2',
-            // OpenRouter - Mistral models
-            'mistralai/mistral-small-3.2-24b-instruct-2506': 'Mistral Small 3.2 24B',
-            'mistralai/magistral-small-2506': 'Magistral Small',
-            'mistralai/magistral-medium-2506': 'Magistral Medium',
-            'mistralai/devstral-small-2505': 'Devstral Small',
-            'mistralai/mistral-medium-3': 'Mistral Medium 3',
-            'mistralai/mistral-small-3.1-24b-instruct-2503': 'Mistral Small 3.1 24B',
-            'mistralai/mistral-saba-2502': 'Mistral Saba',
-            'mistralai/mistral-small-24b-instruct-2501': 'Mistral Small 24B',
-            'mistralai/codestral-2501': 'Codestral',
-            'mistralai/mistral-large-2411': 'Mistral Large 2411',
-            'mistralai/mistral-large-2407': 'Mistral Large 2407',
-            'mistralai/pixtral-large-2411': 'Pixtral Large',
-            'mistralai/pixtral-12b': 'Pixtral 12B',
-            'mistralai/ministral-8b': 'Ministral 8B',
-            'mistralai/ministral-3b': 'Ministral 3B',
-            'mistralai/mistral-nemo': 'Mistral Nemo',
-            'mistralai/mistral-large': 'Mistral Large',
-            'mistralai/mixtral-8x22b-instruct': 'Mixtral 8x22B',
-            'mistralai/mixtral-8x7b-instruct': 'Mixtral 8x7B',
-            'mistralai/mistral-7b-instruct': 'Mistral 7B',
-            // OpenRouter - xAI models
-            'x-ai/grok-3': 'Grok 3',
-            'x-ai/grok-3-mini': 'Grok 3 Mini',
-            'x-ai/grok-3-beta': 'Grok 3 Beta',
-            'x-ai/grok-3-mini-beta': 'Grok 3 Mini Beta',
-            'x-ai/grok-2-vision-1212': 'Grok 2 Vision',
-            'x-ai/grok-2-1212': 'Grok 2',
-            'x-ai/grok-vision-beta': 'Grok Vision Beta',
-            'x-ai/grok-code-fast-1': 'Grok Code Fast 1',
-            // OpenRouter - Qwen models
-            'qwen/qwen3-235b-a22b-04-28': 'Qwen3 235B',
-            'qwen/qwen3-32b-04-28': 'Qwen3 32B',
-            'qwen/qwen3-30b-a3b-04-28': 'Qwen3 30B',
-            'qwen/qwen3-14b-04-28': 'Qwen3 14B',
-            'qwen/qwen3-8b-04-28': 'Qwen3 8B',
-            'qwen/qwen2.5-vl-72b-instruct': 'Qwen2.5 VL 72B',
-            'qwen/qwen2.5-vl-32b-instruct': 'Qwen2.5 VL 32B',
-            'qwen/qwen-2.5-coder-32b-instruct': 'Qwen 2.5 Coder 32B',
-            'qwen/qwen-2.5-72b-instruct': 'Qwen 2.5 72B',
-            'qwen/qwen-2.5-7b-instruct': 'Qwen 2.5 7B',
-            'qwen/qwen-2-72b-instruct': 'Qwen 2 72B',
-            'qwen/qwen-2-vl-7b-instruct': 'Qwen 2 VL 7B',
-            'qwen/qwq-32b': 'QwQ 32B',
-            'qwen/qwq-32b-preview': 'QwQ 32B Preview',
-            'qwen/qwen-vl-max-2025-01-25': 'Qwen VL Max',
-            'qwen/qwen-vl-plus': 'Qwen VL Plus',
-            'qwen/qwen-max-2025-01-25': 'Qwen Max',
-            'qwen/qwen-plus-2025-01-25': 'Qwen Plus',
-            'qwen/qwen-turbo-2024-11-01': 'Qwen Turbo',
-            // OpenRouter - Perplexity models
-            'perplexity/sonar-reasoning-pro': 'Sonar Reasoning Pro',
-            'perplexity/sonar-pro': 'Sonar Pro',
-            'perplexity/sonar-deep-research': 'Sonar Deep Research',
-            'perplexity/sonar-reasoning': 'Sonar Reasoning',
-            'perplexity/sonar': 'Sonar',
-            'perplexity/r1-1776': 'R1-1776',
-            'perplexity/llama-3.1-sonar-large-128k-online': 'Llama 3.1 Sonar Large Online',
-            'perplexity/llama-3.1-sonar-small-128k-online': 'Llama 3.1 Sonar Small Online',
-            // OpenRouter - Microsoft models
-            'microsoft/phi-4-reasoning-plus-04-30': 'Phi-4 Reasoning Plus',
-            'microsoft/mai-ds-r1': 'MAI-DS-R1',
-            'microsoft/phi-4-multimodal-instruct': 'Phi-4 Multimodal',
-            'microsoft/phi-4': 'Phi-4',
-            'microsoft/phi-3.5-mini-128k-instruct': 'Phi-3.5 Mini',
-            'microsoft/phi-3-medium-128k-instruct': 'Phi-3 Medium',
-            'microsoft/phi-3-mini-128k-instruct': 'Phi-3 Mini',
-            'microsoft/wizardlm-2-8x22b': 'WizardLM-2 8x22B',
-            // OpenRouter - NVIDIA models
-            'nvidia/llama-3.3-nemotron-super-49b-v1': 'Llama 3.3 Nemotron Super 49B',
-            'nvidia/llama-3.1-nemotron-ultra-253b-v1': 'Llama 3.1 Nemotron Ultra 253B',
-            'nvidia/llama-3.1-nemotron-70b-instruct': 'Llama 3.1 Nemotron 70B',
-            // OpenRouter - Other models
-            'minimax/minimax-01': 'MiniMax-01',
-            'minimax/minimax-m1': 'MiniMax-M1',
-            'liquid/lfm-40b': 'LFM 40B',
-            'liquid/lfm-7b': 'LFM 7B',
-            'liquid/lfm-3b': 'LFM 3B',
-            'cohere/command-a-03-2025': 'Command A',
-            'cohere/command-r7b-12-2024': 'Command R7B',
-            'cohere/command-r-plus': 'Command R Plus',
-            'cohere/command-r': 'Command R',
-            'amazon/nova-pro-v1': 'Nova Pro',
-            'amazon/nova-lite-v1': 'Nova Lite',
-            'amazon/nova-micro-v1': 'Nova Micro',
-            'ai21/jamba-1.6-large': 'Jamba 1.6 Large',
-            'ai21/jamba-1.6-mini': 'Jamba 1.6 Mini',
-            '01-ai/yi-large': 'Yi Large',
-            'inflection/inflection-3-productivity': 'Inflection 3 Productivity',
-            'inflection/inflection-3-pi': 'Inflection 3 Pi',
-            'rekaai/reka-flash-3': 'Reka Flash 3',
-            'openrouter/auto': 'Auto (Best Available)'
+            'google/gemini-2.5-flash': 'Gemini 2.5 Flash'
         };
-        
+
         return modelNames[model] || model;
     }
 } 

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -130,7 +130,7 @@ export class ChatMessageService {
                 // Determine which provider is currently selected to show specific error
                 const config = vscode.workspace.getConfiguration('superdesign');
                 const specificModel = config.get<string>('aiModel');
-                const provider = config.get<string>('aiModelProvider', 'anthropic');
+                const provider = config.get<string>('aiModelProvider', 'openai');
                 const openaiUrl = config.get<string>('openaiUrl');
                 
                 // Determine provider from model name if specific model is set, ignore if custom openai url is used
@@ -154,8 +154,8 @@ export class ChatMessageService {
                         configureCommand = 'superdesign.configureOpenRouterApiKey';
                         break;
                     case 'anthropic':
-                        providerName = 'Anthropic';
-                        configureCommand = 'superdesign.configureApiKey';
+                        providerName = 'Anthropic (unsupported)';
+                        configureCommand = 'workbench.action.openSettings';
                         break;
                     case 'claude-code':
                         providerName = 'Claude Code';
@@ -168,10 +168,12 @@ export class ChatMessageService {
                 }
                 
                 const hasApiKey = this.agentService.hasApiKey();
-                const displayMessage = hasApiKey ? 
-                    `Invalid ${providerName} API key. Please check your configuration.` : 
-                    `${providerName} API key not configured. Please set up your API key to use this AI model.`;
-                    
+                const displayMessage = effectiveProvider === 'anthropic' ?
+                    'Anthropic provider is no longer supported. Please switch to OpenAI or OpenRouter.' :
+                    (hasApiKey ?
+                        `Invalid ${providerName} API key. Please check your configuration.` :
+                        `${providerName} API key not configured. Please set up your API key to use this AI model.`);
+
                 webview.postMessage({
                     command: 'chatErrorWithActions',
                     error: displayMessage,

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -83,7 +83,7 @@ export class CustomAgentService implements AgentService {
     private getModel() {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
+        const provider = config.get<string>('aiModelProvider', 'openai');
         const openaiUrl = config.get<string>('openaiUrl');
         
         this.outputChannel.appendLine(`Using AI provider: ${provider}`);
@@ -116,32 +116,14 @@ export class CustomAgentService implements AgentService {
                     apiKey: openrouterKey
                 });
                 
-                // Use specific model if available, otherwise default to Claude 3.7 Sonnet via OpenRouter
-                const openrouterModel = specificModel || 'anthropic/claude-3-7-sonnet-20250219';
+                // Use specific model if available, otherwise default to Gemini 2.5 Pro via OpenRouter
+                const openrouterModel = specificModel || 'google/gemini-2.5-pro';
                 this.outputChannel.appendLine(`Using OpenRouter model: ${openrouterModel}`);
                 return openrouter.chat(openrouterModel);
                 
             case 'anthropic':
-                const anthropicKey = config.get<string>('anthropicApiKey');
-                if (!anthropicKey) {
-                    throw new Error('Anthropic API key not configured. Please run "Configure Anthropic API Key" command.');
-                }
-                
-                this.outputChannel.appendLine(`Anthropic API key found: ${anthropicKey.substring(0, 12)}...`);
-                
-                const anthropic = createAnthropic({
-                    apiKey: anthropicKey,
-                    baseURL: "https://anthropic.helicone.ai/v1",
-                    headers: {
-                        "Helicone-Auth": `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
-                    }
-                });
-                
-                // Use specific model if available, otherwise default to claude-3-5-sonnet
-                const anthropicModel = specificModel || 'claude-3-5-sonnet-20241022';
-                this.outputChannel.appendLine(`Using Anthropic model: ${anthropicModel}`);
-                return anthropic(anthropicModel);
-                
+                throw new Error('Anthropic provider is no longer supported. Please switch to OpenAI or OpenRouter.');
+
             case 'claude-code':
                 // This case is handled in the query method before reaching this point
                 throw new Error('Claude Code provider should be handled before getModel() is called');
@@ -149,7 +131,7 @@ export class CustomAgentService implements AgentService {
             case 'openai':
             default:
                 const openaiKey = config.get<string>('openaiApiKey');
-                 const openaiUrl = config.get<string>('openaiUrl');
+                const openaiUrl = config.get<string>('openaiUrl');
                 if (!openaiKey) {
                     throw new Error('OpenAI API key not configured. Please run "Configure OpenAI API Key" command.');
                 }
@@ -164,8 +146,8 @@ export class CustomAgentService implements AgentService {
                     }
                 });
                 
-                // Use specific model if available, otherwise default to gpt-4o
-                const openaiModel = specificModel || 'gpt-4o';
+                // Use specific model if available, otherwise default to GPT-5
+                const openaiModel = specificModel || 'gpt-5';
                 this.outputChannel.appendLine(`Using OpenAI model: ${openaiModel}`);
                 return openai(openaiModel);
         }
@@ -174,7 +156,7 @@ export class CustomAgentService implements AgentService {
     private getSystemPrompt(): string {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
+        const provider = config.get<string>('aiModelProvider', 'openai');
         
         // Determine the actual model name being used
         let modelName: string;
@@ -184,17 +166,17 @@ export class CustomAgentService implements AgentService {
             // Use defaults based on provider
             switch (provider) {
                 case 'openai':
-                    modelName = 'gpt-4o';
+                    modelName = 'gpt-5';
                     break;
                 case 'openrouter':
-                    modelName = 'anthropic/claude-3-7-sonnet-20250219';
+                    modelName = 'google/gemini-2.5-pro';
                     break;
                 case 'claude-code':
                     modelName = 'claude-code';
                     break;
                 case 'anthropic':
                 default:
-                    modelName = 'claude-3-5-sonnet-20241022';
+                    modelName = 'gpt-5';
                     break;
             }
         }
@@ -603,7 +585,7 @@ I've created the html design, please reveiw and let me know if you need any chan
 
         // Check if claude-code is selected and use ClaudeCodeService instead
         const config = vscode.workspace.getConfiguration('superdesign');
-        const aiModelProvider = config.get<string>('aiModelProvider', 'anthropic');
+        const aiModelProvider = config.get<string>('aiModelProvider', 'openai');
         const llmProvider = config.get<string>('llmProvider', 'claude-api');
         
         // If either setting is set to claude-code, use ClaudeCodeService
@@ -943,7 +925,7 @@ I've created the html design, please reveiw and let me know if you need any chan
     hasApiKey(): boolean {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
+        const provider = config.get<string>('aiModelProvider', 'openai');
         const openaiUrl = config.get<string>('openaiUrl');
         
         // Determine provider from model name if specific model is set, ignore if custom openai url is used

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -19,7 +19,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
     const { chatHistory, isLoading, sendMessage, clearHistory, setChatHistory } = useChat(vscode);
     const { isFirstTime, isLoading: isCheckingFirstTime, markAsReturningUser, resetFirstTimeUser } = useFirstTimeUser();
     const [inputMessage, setInputMessage] = useState('');
-    const [selectedModel, setSelectedModel] = useState<string>('claude-3-5-sonnet-20241022');
+    const [selectedModel, setSelectedModel] = useState<string>('gpt-5');
     const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
     const [showFullContent, setShowFullContent] = useState<{[key: string]: boolean}>({});
     const [currentContext, setCurrentContext] = useState<{fileName: string; type: string} | null>(null);
@@ -52,14 +52,14 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                 let fallbackModel: string;
                 switch (message.provider) {
                     case 'openai':
-                        fallbackModel = 'gpt-4o';
+                        fallbackModel = 'gpt-5';
                         break;
                     case 'openrouter':
-                        fallbackModel = 'anthropic/claude-3-7-sonnet-20250219';
+                        fallbackModel = 'google/gemini-2.5-pro';
                         break;
                     case 'anthropic':
                     default:
-                        fallbackModel = 'claude-3-5-sonnet-20241022';
+                        fallbackModel = 'gpt-5';
                         break;
                 }
                 setSelectedModel(message.model || fallbackModel);

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -22,44 +22,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
     const modalRef = useRef<HTMLDivElement>(null);
 
     const models: ModelOption[] = [
-        // Anthropic
-        { id: 'claude-4-opus-20250514', name: 'Claude 4 Opus', provider: 'Anthropic', category: 'Premium' },
-        { id: 'claude-4-sonnet-20250514', name: 'Claude 4 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        // Google (OpenRouter)
+        { id: 'gpt-5', name: 'GPT-5', provider: 'OpenAI', category: 'Balanced' },
+        { id: 'gpt-5-mini', name: 'GPT-5 Mini', provider: 'OpenAI', category: 'Fast' },
         { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'OpenRouter (Google)', category: 'Balanced' },
-        // Meta (OpenRouter)
-        { id: 'meta-llama/llama-4-maverick-17b-128e-instruct', name: 'Llama 4 Maverick 17B', provider: 'OpenRouter (Meta)', category: 'Balanced' },
-        // DeepSeek (OpenRouter)
-        { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
-        // Mistral (OpenRouter)
-        { id: 'mistralai/mistral-small-3.2-24b-instruct-2506', name: 'Mistral Small 3.2 24B', provider: 'OpenRouter (Mistral)', category: 'Balanced' },
-        // xAI (OpenRouter)
-        { id: 'x-ai/grok-3', name: 'Grok 3', provider: 'OpenRouter (xAI)', category: 'Balanced' },
-        // Qwen (OpenRouter)
-        { id: 'qwen/qwen3-235b-a22b-04-28', name: 'Qwen3 235B', provider: 'OpenRouter (Qwen)', category: 'Balanced' },
-        // Perplexity (OpenRouter)
-        { id: 'perplexity/sonar-reasoning-pro', name: 'Sonar Reasoning Pro', provider: 'OpenRouter (Perplexity)', category: 'Balanced' },
-        // Microsoft (OpenRouter)
-        { id: 'microsoft/phi-4-reasoning-plus-04-30', name: 'Phi-4 Reasoning Plus', provider: 'OpenRouter (Microsoft)', category: 'Balanced' },
-        // NVIDIA (OpenRouter)
-        { id: 'nvidia/llama-3.3-nemotron-super-49b-v1', name: 'Llama 3.3 Nemotron Super 49B', provider: 'OpenRouter (NVIDIA)', category: 'Balanced' },
-        // Cohere (OpenRouter)
-        { id: 'cohere/command-a-03-2025', name: 'Command A', provider: 'OpenRouter (Cohere)', category: 'Balanced' },
-        // Amazon (OpenRouter)
-        { id: 'amazon/nova-pro-v1', name: 'Nova Pro', provider: 'OpenRouter (Amazon)', category: 'Balanced' },
-        // Inflection (OpenRouter)
-        { id: 'inflection/inflection-3-productivity', name: 'Inflection 3 Productivity', provider: 'OpenRouter (Inflection)', category: 'Balanced' },
-        // Reka (OpenRouter)
-        { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
-        // Additional OpenRouter models
-        { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1', provider: 'OpenRouter (xAI)', category: 'Fast' },
-        { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
-        { id: 'deepseek/deepseek-chat-v3.1:free', name: 'DeepSeek Chat V3.1 Free', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
-        // Existing OpenAI (direct)
-        { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
-        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
+        { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'OpenRouter (Google)', category: 'Fast' }
     ];
 
     const filteredModels = models.filter(model =>


### PR DESCRIPTION
# Summary
- default the extension to the OpenAI provider and update configuration copy for the remaining models
- trim the model selector, sidebar provider, and chat UI to only offer GPT-5, GPT-5 Mini, Gemini 2.5 Pro, and Gemini 2.5 Flash
- align the agent and error handling logic with the new defaults and retire the Anthropic provider path

## Testing
- not run (not requested)

