### PR TITLE
Reintroduce OpenRouter and Gemini provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,18 @@
         "category": "Superdesign"
       },
       {
-        "command": "superdesign.configureOpenAIUrl",
-        "title": "Configure OpenAI url",
+        "command": "superdesign.configureOpenRouterApiKey",
+        "title": "Configure OpenRouter API Key",
         "category": "Superdesign"
       },
       {
-        "command": "superdesign.configureOpenRouterApiKey",
-        "title": "Configure OpenRouter API Key",
+        "command": "superdesign.configureGeminiApiKey",
+        "title": "Configure Gemini API Key",
+        "category": "Superdesign"
+      },
+      {
+        "command": "superdesign.configureOpenAIUrl",
+        "title": "Configure OpenAI url",
         "category": "Superdesign"
       },
       {
@@ -190,14 +195,19 @@
           "description": "OpenAI API key for custom agent",
           "scope": "application"
         },
+        "superdesign.openrouterApiKey": {
+          "type": "string",
+          "description": "OpenRouter API key for custom agent",
+          "scope": "application"
+        },
         "superdesign.openaiUrl": {
           "type": "string",
           "description": "OpenAI url for custom agent",
           "scope": "application"
         },
-        "superdesign.openrouterApiKey": {
+        "superdesign.geminiApiKey": {
           "type": "string",
-          "description": "OpenRouter API key for custom agent",
+          "description": "Google Gemini API key for custom agent",
           "scope": "application"
         },
         "superdesign.aiModelProvider": {
@@ -206,10 +216,11 @@
             "openai",
             "anthropic",
             "openrouter",
+            "gemini",
             "claude-code"
           ],
-          "default": "anthropic",
-          "description": "AI model provider for custom agent (OpenAI, Anthropic, OpenRouter, or Claude Code - Note: Claude Code should be used via the main LLM Provider setting instead)",
+          "default": "openai",
+          "description": "AI model provider for custom agent (OpenAI, Anthropic, OpenRouter, Google Gemini, or Claude Code - Note: Claude Code should be used via the main LLM Provider setting instead)",
           "scope": "application"
         },
         "superdesign.aiModel": {
@@ -260,8 +271,8 @@
     "@ai-sdk/anthropic": "^1.2.12",
     "@ai-sdk/google": "^1.2.19",
     "@ai-sdk/openai": "^1.3.22",
-    "@anthropic-ai/claude-code": "^1.0.31",
     "@openrouter/ai-sdk-provider": "^0.7.2",
+    "@anthropic-ai/claude-code": "^1.0.31",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "ai": "^4.3.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,48 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.2.12
+        version: 1.2.12(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^1.2.19
+        version: 1.2.22(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^1.3.22
+        version: 1.3.24(zod@3.25.76)
       '@anthropic-ai/claude-code':
         specifier: ^1.0.31
         version: 1.0.33
+      '@openrouter/ai-sdk-provider':
+        specifier: ^0.7.2
+        version: 0.7.5(ai@4.3.19(react@19.1.0)(zod@3.25.76))(zod@3.25.76)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      ai:
+        specifier: ^4.3.16
+        version: 4.3.19(react@19.1.0)(zod@3.25.76)
+      execa:
+        specifier: ^9.6.0
+        version: 9.6.0
+      glob:
+        specifier: ^11.0.3
+        version: 11.0.3
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
       lucide-react:
         specifier: ^0.522.0
         version: 0.522.0(react@19.1.0)
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
+      mime-types:
+        specifier: ^3.0.1
+        version: 3.0.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -41,7 +68,13 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.76
     devDependencies:
+      '@types/mime-types':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -49,7 +82,7 @@ importers:
         specifier: 20.x
         version: 20.19.1
       '@types/vscode':
-        specifier: ^1.95.0
+        specifier: ^1.90.0
         version: 1.101.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.31.1
@@ -72,11 +105,58 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
 
 packages:
+
+  '@ai-sdk/anthropic@1.2.12':
+    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/google@1.2.22':
+    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/openai@1.3.24':
+    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@anthropic-ai/claude-code@1.0.33':
     resolution: {integrity: sha512-rKQ1C0+iSV/bS4LVfyCt2FIkIc8MnFi5EbmRAXEunNkXLCQLHfXjsqx7cLOy7c11vZwGkyf/wEp5LwaDQHdjCQ==}
@@ -85,6 +165,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
@@ -359,6 +443,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -377,6 +469,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -389,12 +484,45 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@openrouter/ai-sdk-provider@0.7.5':
+    resolution: {integrity: sha512-zm8vBhQ+GhxN03Y41xviB0nDa20uN77QnMXsIwDeJPqsul8+KycrYFxY4ulXpumeKxjKyOhfyA7a7CJpcYq2ng==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^4.3.17
+      zod: ^3.25.34
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -413,6 +541,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mime-types@3.0.1':
+    resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
 
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
@@ -516,6 +647,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -524,6 +659,16 @@ packages:
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -555,6 +700,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -694,6 +842,9 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -750,6 +901,13 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -868,6 +1026,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@9.6.0:
+    resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -886,6 +1048,10 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -952,6 +1118,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -966,6 +1136,11 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   glob@7.2.3:
@@ -1062,6 +1237,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1207,6 +1386,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1267,6 +1450,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1280,8 +1467,16 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -1324,6 +1519,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   lucide-react@0.522.0:
     resolution: {integrity: sha512-jnJbw974yZ7rQHHEFKJOlWAefG3ATSCZHANZxIdx8Rk/16siuwjgA4fBULpXEAWx/RlTs3FzmKW/udWUuO0aRw==}
     peerDependencies:
@@ -1332,6 +1531,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1481,9 +1683,21 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
+    engines: {node: '>= 0.6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1508,6 +1722,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -1525,6 +1744,10 @@ packages:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
     engines: {node: '>= 4'}
     hasBin: true
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1582,6 +1805,10 @@ packages:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1598,12 +1825,20 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -1629,6 +1864,10 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -1746,6 +1985,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -1883,6 +2125,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1913,6 +2159,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.6:
+    resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tapable@2.2.2:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
@@ -1920,6 +2171,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1936,6 +2191,20 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1969,6 +2238,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -1993,8 +2266,16 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -2076,14 +2357,76 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
+    peerDependencies:
+      zod: ^3.24.1
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/google@1.2.22(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 19.1.0
+      swr: 2.3.6(react@19.1.0)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
   '@anthropic-ai/claude-code@1.0.33':
     optionalDependencies:
@@ -2095,6 +2438,10 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@esbuild/aix-ppc64@0.25.5':
     optional: true
@@ -2275,6 +2622,12 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2295,6 +2648,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2307,12 +2665,35 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@openrouter/ai-sdk-provider@0.7.5(ai@4.3.19(react@19.1.0)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      ai: 4.3.19(react@19.1.0)(zod@3.25.76)
+      zod: 3.25.76
+
+  '@opentelemetry/api@1.9.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
 
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/diff-match-patch@1.0.36': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -2331,6 +2712,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mime-types@3.0.1': {}
 
   '@types/mocha@10.0.10': {}
 
@@ -2474,9 +2857,25 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.15.0: {}
 
   agent-base@7.1.3: {}
+
+  ai@4.3.19(react@19.1.0)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 19.1.0
 
   ajv@6.12.6:
     dependencies:
@@ -2505,6 +2904,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -2658,6 +3059,8 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  create-require@1.1.1: {}
+
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -2723,6 +3126,10 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff-match-patch@1.0.5: {}
+
+  diff@4.0.2: {}
 
   diff@5.2.0: {}
 
@@ -2932,6 +3339,21 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@9.6.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2951,6 +3373,10 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3023,6 +3449,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -3045,6 +3476,15 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   glob@7.2.3:
     dependencies:
@@ -3158,6 +3598,8 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  human-signals@8.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -3293,6 +3735,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@4.0.1: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -3350,6 +3794,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -3360,7 +3808,15 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.4.1
+      diff-match-patch: 1.0.5
 
   jszip@3.10.1:
     dependencies:
@@ -3415,6 +3871,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.2: {}
+
   lucide-react@0.522.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -3422,6 +3880,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.2
+
+  make-error@1.3.6: {}
 
   markdown-table@3.0.4: {}
 
@@ -3780,7 +4240,17 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-function@5.0.1: {}
+
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.1.2:
     dependencies:
@@ -3821,6 +4291,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   natural-compare@1.4.0: {}
 
   nice-try@1.0.5: {}
@@ -3845,6 +4317,11 @@ snapshots:
       read-pkg: 3.0.0
       shell-quote: 1.8.3
       string.prototype.padend: 3.1.6
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   object-inspect@1.13.4: {}
 
@@ -3925,6 +4402,8 @@ snapshots:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
 
+  parse-ms@4.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -3933,11 +4412,18 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.2.2
       minipass: 7.1.2
 
   path-type@3.0.0:
@@ -3953,6 +4439,10 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   prelude-ls@1.2.1: {}
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
 
@@ -4124,6 +4614,8 @@ snapshots:
 
   scheduler@0.26.0: {}
 
+  secure-json-parse@2.7.0: {}
+
   semver@5.7.2: {}
 
   semver@7.7.2: {}
@@ -4290,6 +4782,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@4.0.0: {}
+
   strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.17:
@@ -4316,6 +4810,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.6(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   tapable@2.2.2: {}
 
   test-exclude@6.0.0:
@@ -4323,6 +4823,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  throttleit@2.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4335,6 +4837,24 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   type-check@0.4.0:
     dependencies:
@@ -4384,6 +4904,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -4426,7 +4948,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   util-deprecate@1.0.2: {}
+
+  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -4549,6 +5077,16 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yn@3.1.1: {}
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.24.6(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1270,9 +1270,13 @@ export function activate(context: vscode.ExtensionContext) {
 		await configureOpenAIApiKey();
 	});
 
-	const configureOpenRouterApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureOpenRouterApiKey', async () => {
-		await configureOpenRouterApiKey();
-	});
+        const configureOpenRouterApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureOpenRouterApiKey', async () => {
+                await configureOpenRouterApiKey();
+        });
+
+        const configureGeminiApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureGeminiApiKey', async () => {
+                await configureGeminiApiKey();
+        });
 
   const configureOpenAIUrlDisposable = vscode.commands.registerCommand('superdesign.configureOpenAIUrl', async () => {
     await configureOpenAIUrl();
@@ -1393,8 +1397,9 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		helloWorldDisposable, 
 		configureApiKeyDisposable,
-		configureOpenAIApiKeyDisposable,
-		configureOpenRouterApiKeyDisposable,
+                configureOpenAIApiKeyDisposable,
+                configureOpenRouterApiKeyDisposable,
+                configureGeminiApiKeyDisposable,
     configureOpenAIUrlDisposable,
 		sidebarDisposable,
 		showSidebarDisposable,
@@ -1454,7 +1459,7 @@ async function configureAnthropicApiKey() {
 
 // Function to configure OpenAI API key
 async function configureOpenAIApiKey() {
-	const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('openaiApiKey');
+        const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('openaiApiKey');
 
 	const input = await vscode.window.showInputBox({
 		title: 'Configure OpenAI API Key',
@@ -1499,47 +1504,87 @@ async function configureOpenAIApiKey() {
 
 // Function to configure OpenRouter API key
 async function configureOpenRouterApiKey() {
-	const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('openrouterApiKey');
+        const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('openrouterApiKey');
 
-	const input = await vscode.window.showInputBox({
-		title: 'Configure OpenRouter API Key',
-		prompt: 'Enter your OpenRouter API key (get one from https://openrouter.ai/)',
-		value: currentKey ? '••••••••••••••••' : '',
-		password: true,
-		placeHolder: 'sk-...',
-		validateInput: (value) => {
-			if (!value || value.trim().length === 0) {
-				return 'API key cannot be empty';
-			}
-			if (value === '••••••••••••••••') {
-				return null; // User didn't change the masked value, that's OK
-			}
-			if (!value.startsWith('sk-')) {
-				return 'OpenRouter API keys should start with "sk-"';
-			}
-			return null;
-		}
-	});
+        const input = await vscode.window.showInputBox({
+                title: 'Configure OpenRouter API Key',
+                prompt: 'Enter your OpenRouter API key (get one from https://openrouter.ai/)',
+                value: currentKey ? '••••••••••••••••' : '',
+                password: true,
+                placeHolder: 'sk-...',
+                validateInput: (value) => {
+                        if (!value || value.trim().length === 0) {
+                                return 'API key cannot be empty';
+                        }
+                        if (value === '••••••••••••••••') {
+                                return null; // User didn't change the masked value, that's OK
+                        }
+                        if (!value.startsWith('sk-')) {
+                                return 'OpenRouter API keys should start with "sk-"';
+                        }
+                        return null;
+                }
+        });
 
-	if (input !== undefined) {
-		// Only update if user didn't just keep the masked value
-		if (input !== '••••••••••••••••') {
-			try {
-				await vscode.workspace.getConfiguration('superdesign').update(
-					'openrouterApiKey', 
-					input.trim(), 
-					vscode.ConfigurationTarget.Global
-				);
-				vscode.window.showInformationMessage('✅ OpenRouter API key configured successfully!');
-			} catch (error) {
-				vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
-			}
-		} else if (currentKey) {
-			vscode.window.showInformationMessage('API key unchanged (already configured)');
-		} else {
-			vscode.window.showWarningMessage('No API key was set');
-		}
-	}
+        if (input !== undefined) {
+                if (input !== '••••••••••••••••') {
+                        try {
+                                await vscode.workspace.getConfiguration('superdesign').update(
+                                        'openrouterApiKey',
+                                        input.trim(),
+                                        vscode.ConfigurationTarget.Global
+                                );
+                                vscode.window.showInformationMessage('✅ OpenRouter API key configured successfully!');
+                        } catch (error) {
+                                vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
+                        }
+                } else if (currentKey) {
+                        vscode.window.showInformationMessage('API key unchanged (already configured)');
+                } else {
+                        vscode.window.showWarningMessage('No API key was set');
+                }
+        }
+}
+
+// Function to configure Google Gemini API key
+async function configureGeminiApiKey() {
+        const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('geminiApiKey');
+
+        const input = await vscode.window.showInputBox({
+                title: 'Configure Gemini API Key',
+                prompt: 'Enter your Google Gemini API key (get one from https://aistudio.google.com/app/apikey)',
+                value: currentKey ? '••••••••••••••••' : '',
+                password: true,
+                placeHolder: 'AI... orAIza...',
+                validateInput: (value) => {
+                        if (!value || value.trim().length === 0) {
+                                return 'API key cannot be empty';
+                        }
+                        if (value === '••••••••••••••••') {
+                                return null; // User didn't change the masked value, that's OK
+                        }
+                        return null;
+                }
+        });
+
+        if (input !== undefined) {
+                if (input !== '••••••••••••••••') {
+                        try {
+                                await vscode.workspace.getConfiguration('superdesign').update(
+                                        'geminiApiKey',
+                                        input.trim(),
+                                        vscode.ConfigurationTarget.Global
+                                );
+                                vscode.window.showInformationMessage('✅ Gemini API key configured successfully!');
+                        } catch (error) {
+                                vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
+                        }
+                } else if (currentKey) {
+                        vscode.window.showInformationMessage('API key unchanged (already configured)');
+                } else {
+                        vscode.window.showWarningMessage('No API key was set');
+                }
+        }
 }
 
 // Function to configure OpenAI url

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -99,6 +99,11 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         const config = vscode.workspace.getConfiguration('superdesign');
         const currentProvider = config.get<string>('aiModelProvider', 'openai');
         const currentModel = config.get<string>('aiModel');
+        const normalizedModel = this.normalizeGeminiModelId(currentModel);
+
+        if (normalizedModel && normalizedModel !== currentModel) {
+            await config.update('aiModel', normalizedModel, vscode.ConfigurationTarget.Global);
+        }
 
         // If no specific model is set, use defaults
         let defaultModel: string;
@@ -110,7 +115,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                 defaultModel = 'claude-3-5-sonnet-20241022';
                 break;
             case 'gemini':
-                defaultModel = 'gemini-2.5-pro';
+                defaultModel = 'models/gemini-2.5-pro';
                 break;
             case 'claude-code':
                 defaultModel = 'claude-code';
@@ -124,46 +129,48 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         webview.postMessage({
             command: 'currentProviderResponse',
             provider: currentProvider,
-            model: currentModel || defaultModel
+            model: normalizedModel || defaultModel
         });
     }
 
     private async handleChangeProvider(model: string, webview: vscode.Webview) {
         try {
             const config = vscode.workspace.getConfiguration('superdesign');
-            
+
+            const normalizedModel = this.normalizeGeminiModelId(model) || model;
+
             // Determine provider and API key based on model
             let provider: string;
             let apiKeyKey: string;
             let configureCommand: string;
             let displayName: string;
 
-            if (model.includes('/')) {
-                provider = 'openrouter';
-                apiKeyKey = 'openrouterApiKey';
-                configureCommand = 'superdesign.configureOpenRouterApiKey';
-                displayName = `OpenRouter (${this.getModelDisplayName(model)})`;
-            } else if (model.startsWith('claude-')) {
-                provider = 'anthropic';
-                apiKeyKey = 'anthropicApiKey';
-                configureCommand = 'superdesign.configureApiKey';
-                displayName = `Anthropic (${this.getModelDisplayName(model)})`;
-            } else if (model.startsWith('gemini-')) {
+            if (this.isGeminiModel(normalizedModel)) {
                 provider = 'gemini';
                 apiKeyKey = 'geminiApiKey';
                 configureCommand = 'superdesign.configureGeminiApiKey';
-                displayName = `Google Gemini (${this.getModelDisplayName(model)})`;
+                displayName = `Google Gemini (${this.getModelDisplayName(normalizedModel)})`;
+            } else if (normalizedModel.includes('/')) {
+                provider = 'openrouter';
+                apiKeyKey = 'openrouterApiKey';
+                configureCommand = 'superdesign.configureOpenRouterApiKey';
+                displayName = `OpenRouter (${this.getModelDisplayName(normalizedModel)})`;
+            } else if (normalizedModel.startsWith('claude-')) {
+                provider = 'anthropic';
+                apiKeyKey = 'anthropicApiKey';
+                configureCommand = 'superdesign.configureApiKey';
+                displayName = `Anthropic (${this.getModelDisplayName(normalizedModel)})`;
             } else {
                 provider = 'openai';
                 apiKeyKey = 'openaiApiKey';
                 configureCommand = 'superdesign.configureOpenAIApiKey';
-                displayName = `OpenAI (${this.getModelDisplayName(model)})`;
+                displayName = `OpenAI (${this.getModelDisplayName(normalizedModel)})`;
             }
-            
+
             // Update both provider and specific model
             await config.update('aiModelProvider', provider, vscode.ConfigurationTarget.Global);
-            await config.update('aiModel', model, vscode.ConfigurationTarget.Global);
-            
+            await config.update('aiModel', normalizedModel, vscode.ConfigurationTarget.Global);
+
             // Check if the API key is configured for the selected provider
             const apiKey = config.get<string>(apiKeyKey);
             
@@ -183,7 +190,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             webview.postMessage({
                 command: 'providerChanged',
                 provider: provider,
-                model: model
+                model: normalizedModel
             });
 
         } catch (error) {
@@ -209,7 +216,9 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
             // Gemini models
             'gemini-2.5-pro': 'Gemini 2.5 Pro',
+            'models/gemini-2.5-pro': 'Gemini 2.5 Pro',
             'gemini-2.5-flash': 'Gemini 2.5 Flash',
+            'models/gemini-2.5-flash': 'Gemini 2.5 Flash',
             // OpenRouter models
             'anthropic/claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet (OpenRouter)',
             'google/gemini-2.5-pro': 'Gemini 2.5 Pro (OpenRouter)',
@@ -231,5 +240,25 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         };
 
         return modelNames[model] || model;
+    }
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
+    }
+
+    private normalizeGeminiModelId(model?: string): string | undefined {
+        if (!model) {
+            return undefined;
+        }
+
+        if (model.startsWith('models/')) {
+            return model;
+        }
+
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+
+        return model;
     }
 }

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -97,21 +97,27 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
 
     private async handleGetCurrentProvider(webview: vscode.Webview) {
         const config = vscode.workspace.getConfiguration('superdesign');
-        const currentProvider = config.get<string>('aiModelProvider', 'anthropic');
+        const currentProvider = config.get<string>('aiModelProvider', 'openai');
         const currentModel = config.get<string>('aiModel');
-        
+
         // If no specific model is set, use defaults
         let defaultModel: string;
         switch (currentProvider) {
-            case 'openai':
-                defaultModel = 'gpt-4o';
-                break;
             case 'openrouter':
                 defaultModel = 'anthropic/claude-3-7-sonnet-20250219';
                 break;
             case 'anthropic':
-            default:
                 defaultModel = 'claude-3-5-sonnet-20241022';
+                break;
+            case 'gemini':
+                defaultModel = 'gemini-2.5-pro';
+                break;
+            case 'claude-code':
+                defaultModel = 'claude-code';
+                break;
+            case 'openai':
+            default:
+                defaultModel = 'gpt-5';
                 break;
         }
         
@@ -131,9 +137,8 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             let apiKeyKey: string;
             let configureCommand: string;
             let displayName: string;
-            
+
             if (model.includes('/')) {
-                // OpenRouter model (contains slash like "openai/gpt-4o")
                 provider = 'openrouter';
                 apiKeyKey = 'openrouterApiKey';
                 configureCommand = 'superdesign.configureOpenRouterApiKey';
@@ -143,6 +148,11 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                 apiKeyKey = 'anthropicApiKey';
                 configureCommand = 'superdesign.configureApiKey';
                 displayName = `Anthropic (${this.getModelDisplayName(model)})`;
+            } else if (model.startsWith('gemini-')) {
+                provider = 'gemini';
+                apiKeyKey = 'geminiApiKey';
+                configureCommand = 'superdesign.configureGeminiApiKey';
+                displayName = `Google Gemini (${this.getModelDisplayName(model)})`;
             } else {
                 provider = 'openai';
                 apiKeyKey = 'openaiApiKey';
@@ -184,160 +194,42 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
     private getModelDisplayName(model: string): string {
         const modelNames: { [key: string]: string } = {
             // OpenAI models
+            'gpt-5': 'GPT-5',
+            'gpt-5-codex': 'GPT-5 Codex',
+            'gpt-5-mini': 'GPT-5 Mini',
             'gpt-4.1': 'GPT-4.1',
             'gpt-4.1-mini': 'GPT-4.1 Mini',
             'gpt-4.1-nano': 'GPT-4.1 Nano',
             'gpt-4o': 'GPT-4o',
             'gpt-4o-mini': 'GPT-4o Mini',
-            // Anthropic models
+            // Anthropic direct
             'claude-4-opus-20250514': 'Claude 4 Opus',
             'claude-4-sonnet-20250514': 'Claude 4 Sonnet',
             'claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet',
-            'anthropic/claude-sonnet-4': 'Claude Sonnet 4',
             'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
-            'claude-3-opus-20240229': 'Claude 3 Opus',
-            'claude-3-sonnet-20240229': 'Claude 3 Sonnet',
-            'claude-3-haiku-20240307': 'Claude 3 Haiku',
-            // OpenRouter - Google models
-            'google/gemini-2.5-pro': 'Gemini 2.5 Pro',
-            'google/gemini-2.5-flash': 'Gemini 2.5 Flash',
-            'google/gemini-2.5-pro-preview-06-05': 'Gemini 2.5 Pro Preview',
-            'google/gemini-2.5-flash-preview-05-20': 'Gemini 2.5 Flash Preview',
-            'google/gemini-2.5-pro-preview-03-25': 'Gemini 2.5 Pro Preview (Mar)',
-            'google/gemini-2.0-flash-001': 'Gemini 2.0 Flash',
-            'google/gemini-2.0-flash-exp': 'Gemini 2.0 Flash Exp',
-            'google/gemini-2.0-flash-lite-001': 'Gemini 2.0 Flash Lite',
-            'google/gemma-3-27b-it': 'Gemma 3 27B',
-            'google/gemma-3-12b-it': 'Gemma 3 12B',
-            'google/gemma-3-4b-it': 'Gemma 3 4B',
-            'google/gemma-2-27b-it': 'Gemma 2 27B',
-            'google/gemma-2-9b-it': 'Gemma 2 9B',
-            'google/gemini-flash-1.5': 'Gemini Flash 1.5',
-            'google/gemini-flash-1.5-8b': 'Gemini Flash 1.5 8B',
-            'google/gemini-pro-1.5': 'Gemini Pro 1.5',
-            // OpenRouter - Meta models
-            'meta-llama/llama-4-maverick-17b-128e-instruct': 'Llama 4 Maverick 17B',
-            'meta-llama/llama-4-scout-17b-16e-instruct': 'Llama 4 Scout 17B',
-            'meta-llama/llama-3.3-70b-instruct': 'Llama 3.3 70B',
-            'meta-llama/llama-3.2-90b-vision-instruct': 'Llama 3.2 90B Vision',
-            'meta-llama/llama-3.2-11b-vision-instruct': 'Llama 3.2 11B Vision',
-            'meta-llama/llama-3.2-3b-instruct': 'Llama 3.2 3B',
-            'meta-llama/llama-3.2-1b-instruct': 'Llama 3.2 1B',
-            'meta-llama/llama-3.1-405b-instruct': 'Llama 3.1 405B',
-            'meta-llama/llama-3.1-70b-instruct': 'Llama 3.1 70B',
-            'meta-llama/llama-3.1-8b-instruct': 'Llama 3.1 8B',
-            'meta-llama/llama-3-70b-instruct': 'Llama 3 70B',
-            'meta-llama/llama-3-8b-instruct': 'Llama 3 8B',
-            'meta-llama/llama-guard-4-12b': 'Llama Guard 4 12B',
-            'meta-llama/llama-guard-3-8b': 'Llama Guard 3 8B',
-            'meta-llama/llama-guard-2-8b': 'Llama Guard 2 8B',
-            // OpenRouter - DeepSeek models
-            'deepseek/deepseek-r1': 'DeepSeek R1',
-            'deepseek/deepseek-r1-0528': 'DeepSeek R1 0528',
-            'deepseek/deepseek-r1-distill-llama-70b': 'DeepSeek R1 Distill Llama 70B',
-            'deepseek/deepseek-r1-distill-llama-8b': 'DeepSeek R1 Distill Llama 8B',
-            'deepseek/deepseek-r1-distill-qwen-32b': 'DeepSeek R1 Distill Qwen 32B',
-            'deepseek/deepseek-r1-distill-qwen-14b': 'DeepSeek R1 Distill Qwen 14B',
-            'deepseek/deepseek-r1-distill-qwen-7b': 'DeepSeek R1 Distill Qwen 7B',
-            'deepseek/deepseek-r1-distill-qwen-1.5b': 'DeepSeek R1 Distill Qwen 1.5B',
-            'deepseek/deepseek-chat-v3': 'DeepSeek Chat V3',
-            'deepseek/deepseek-chat-v3.1:free': 'DeepSeek Chat V3.1 Free',
-            'deepseek/deepseek-v3-base': 'DeepSeek V3 Base',
-            'deepseek/deepseek-prover-v2': 'DeepSeek Prover V2',
-            // OpenRouter - Mistral models
-            'mistralai/mistral-small-3.2-24b-instruct-2506': 'Mistral Small 3.2 24B',
-            'mistralai/magistral-small-2506': 'Magistral Small',
-            'mistralai/magistral-medium-2506': 'Magistral Medium',
-            'mistralai/devstral-small-2505': 'Devstral Small',
-            'mistralai/mistral-medium-3': 'Mistral Medium 3',
-            'mistralai/mistral-small-3.1-24b-instruct-2503': 'Mistral Small 3.1 24B',
-            'mistralai/mistral-saba-2502': 'Mistral Saba',
-            'mistralai/mistral-small-24b-instruct-2501': 'Mistral Small 24B',
-            'mistralai/codestral-2501': 'Codestral',
-            'mistralai/mistral-large-2411': 'Mistral Large 2411',
-            'mistralai/mistral-large-2407': 'Mistral Large 2407',
-            'mistralai/pixtral-large-2411': 'Pixtral Large',
-            'mistralai/pixtral-12b': 'Pixtral 12B',
-            'mistralai/ministral-8b': 'Ministral 8B',
-            'mistralai/ministral-3b': 'Ministral 3B',
-            'mistralai/mistral-nemo': 'Mistral Nemo',
-            'mistralai/mistral-large': 'Mistral Large',
-            'mistralai/mixtral-8x22b-instruct': 'Mixtral 8x22B',
-            'mistralai/mixtral-8x7b-instruct': 'Mixtral 8x7B',
-            'mistralai/mistral-7b-instruct': 'Mistral 7B',
-            // OpenRouter - xAI models
-            'x-ai/grok-3': 'Grok 3',
-            'x-ai/grok-3-mini': 'Grok 3 Mini',
-            'x-ai/grok-3-beta': 'Grok 3 Beta',
-            'x-ai/grok-3-mini-beta': 'Grok 3 Mini Beta',
-            'x-ai/grok-2-vision-1212': 'Grok 2 Vision',
-            'x-ai/grok-2-1212': 'Grok 2',
-            'x-ai/grok-vision-beta': 'Grok Vision Beta',
-            'x-ai/grok-code-fast-1': 'Grok Code Fast 1',
-            // OpenRouter - Qwen models
-            'qwen/qwen3-235b-a22b-04-28': 'Qwen3 235B',
-            'qwen/qwen3-32b-04-28': 'Qwen3 32B',
-            'qwen/qwen3-30b-a3b-04-28': 'Qwen3 30B',
-            'qwen/qwen3-14b-04-28': 'Qwen3 14B',
-            'qwen/qwen3-8b-04-28': 'Qwen3 8B',
-            'qwen/qwen2.5-vl-72b-instruct': 'Qwen2.5 VL 72B',
-            'qwen/qwen2.5-vl-32b-instruct': 'Qwen2.5 VL 32B',
-            'qwen/qwen-2.5-coder-32b-instruct': 'Qwen 2.5 Coder 32B',
-            'qwen/qwen-2.5-72b-instruct': 'Qwen 2.5 72B',
-            'qwen/qwen-2.5-7b-instruct': 'Qwen 2.5 7B',
-            'qwen/qwen-2-72b-instruct': 'Qwen 2 72B',
-            'qwen/qwen-2-vl-7b-instruct': 'Qwen 2 VL 7B',
-            'qwen/qwq-32b': 'QwQ 32B',
-            'qwen/qwq-32b-preview': 'QwQ 32B Preview',
-            'qwen/qwen-vl-max-2025-01-25': 'Qwen VL Max',
-            'qwen/qwen-vl-plus': 'Qwen VL Plus',
-            'qwen/qwen-max-2025-01-25': 'Qwen Max',
-            'qwen/qwen-plus-2025-01-25': 'Qwen Plus',
-            'qwen/qwen-turbo-2024-11-01': 'Qwen Turbo',
-            // OpenRouter - Perplexity models
-            'perplexity/sonar-reasoning-pro': 'Sonar Reasoning Pro',
-            'perplexity/sonar-pro': 'Sonar Pro',
-            'perplexity/sonar-deep-research': 'Sonar Deep Research',
-            'perplexity/sonar-reasoning': 'Sonar Reasoning',
-            'perplexity/sonar': 'Sonar',
-            'perplexity/r1-1776': 'R1-1776',
-            'perplexity/llama-3.1-sonar-large-128k-online': 'Llama 3.1 Sonar Large Online',
-            'perplexity/llama-3.1-sonar-small-128k-online': 'Llama 3.1 Sonar Small Online',
-            // OpenRouter - Microsoft models
-            'microsoft/phi-4-reasoning-plus-04-30': 'Phi-4 Reasoning Plus',
-            'microsoft/mai-ds-r1': 'MAI-DS-R1',
-            'microsoft/phi-4-multimodal-instruct': 'Phi-4 Multimodal',
-            'microsoft/phi-4': 'Phi-4',
-            'microsoft/phi-3.5-mini-128k-instruct': 'Phi-3.5 Mini',
-            'microsoft/phi-3-medium-128k-instruct': 'Phi-3 Medium',
-            'microsoft/phi-3-mini-128k-instruct': 'Phi-3 Mini',
-            'microsoft/wizardlm-2-8x22b': 'WizardLM-2 8x22B',
-            // OpenRouter - NVIDIA models
-            'nvidia/llama-3.3-nemotron-super-49b-v1': 'Llama 3.3 Nemotron Super 49B',
-            'nvidia/llama-3.1-nemotron-ultra-253b-v1': 'Llama 3.1 Nemotron Ultra 253B',
-            'nvidia/llama-3.1-nemotron-70b-instruct': 'Llama 3.1 Nemotron 70B',
-            // OpenRouter - Other models
-            'minimax/minimax-01': 'MiniMax-01',
-            'minimax/minimax-m1': 'MiniMax-M1',
-            'liquid/lfm-40b': 'LFM 40B',
-            'liquid/lfm-7b': 'LFM 7B',
-            'liquid/lfm-3b': 'LFM 3B',
-            'cohere/command-a-03-2025': 'Command A',
-            'cohere/command-r7b-12-2024': 'Command R7B',
-            'cohere/command-r-plus': 'Command R Plus',
-            'cohere/command-r': 'Command R',
-            'amazon/nova-pro-v1': 'Nova Pro',
-            'amazon/nova-lite-v1': 'Nova Lite',
-            'amazon/nova-micro-v1': 'Nova Micro',
-            'ai21/jamba-1.6-large': 'Jamba 1.6 Large',
-            'ai21/jamba-1.6-mini': 'Jamba 1.6 Mini',
-            '01-ai/yi-large': 'Yi Large',
-            'inflection/inflection-3-productivity': 'Inflection 3 Productivity',
-            'inflection/inflection-3-pi': 'Inflection 3 Pi',
-            'rekaai/reka-flash-3': 'Reka Flash 3',
-            'openrouter/auto': 'Auto (Best Available)'
+            // Gemini models
+            'gemini-2.5-pro': 'Gemini 2.5 Pro',
+            'gemini-2.5-flash': 'Gemini 2.5 Flash',
+            // OpenRouter models
+            'anthropic/claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet (OpenRouter)',
+            'google/gemini-2.5-pro': 'Gemini 2.5 Pro (OpenRouter)',
+            'meta-llama/llama-4-maverick-17b-128e-instruct': 'Llama 4 Maverick 17B (OpenRouter)',
+            'deepseek/deepseek-r1': 'DeepSeek R1 (OpenRouter)',
+            'mistralai/mistral-small-3.2-24b-instruct-2506': 'Mistral Small 3.2 24B (OpenRouter)',
+            'x-ai/grok-3': 'Grok 3 (OpenRouter)',
+            'qwen/qwen3-235b-a22b-04-28': 'Qwen3 235B (OpenRouter)',
+            'perplexity/sonar-reasoning-pro': 'Sonar Reasoning Pro (OpenRouter)',
+            'microsoft/phi-4-reasoning-plus-04-30': 'Phi-4 Reasoning Plus (OpenRouter)',
+            'nvidia/llama-3.3-nemotron-super-49b-v1': 'Llama 3.3 Nemotron Super 49B (OpenRouter)',
+            'cohere/command-a-03-2025': 'Command A (OpenRouter)',
+            'amazon/nova-pro-v1': 'Nova Pro (OpenRouter)',
+            'inflection/inflection-3-productivity': 'Inflection 3 Productivity (OpenRouter)',
+            'rekaai/reka-flash-3': 'Reka Flash 3 (OpenRouter)',
+            'x-ai/grok-code-fast-1': 'Grok Code Fast 1 (OpenRouter)',
+            'anthropic/claude-sonnet-4': 'Claude Sonnet 4 (OpenRouter)',
+            'deepseek/deepseek-chat-v3.1:free': 'DeepSeek Chat V3.1 Free (OpenRouter)'
         };
-        
+
         return modelNames[model] || model;
     }
-} 
+}

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -130,24 +130,26 @@ export class ChatMessageService {
                 // Determine which provider is currently selected to show specific error
                 const config = vscode.workspace.getConfiguration('superdesign');
                 const specificModel = config.get<string>('aiModel');
-                const provider = config.get<string>('aiModelProvider', 'anthropic');
+                const provider = config.get<string>('aiModelProvider', 'openai');
                 const openaiUrl = config.get<string>('openaiUrl');
-                
+
                 // Determine provider from model name if specific model is set, ignore if custom openai url is used
                 let effectiveProvider = provider;
                 let providerName = 'AI';
-                let configureCommand = 'superdesign.configureApiKey';
-                
-                if (specificModel && !(!openaiUrl && provider === 'openai')) {
+                let configureCommand = 'superdesign.configureOpenAIApiKey';
+
+                if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
                     if (specificModel.includes('/')) {
                         effectiveProvider = 'openrouter';
                     } else if (specificModel.startsWith('claude-')) {
                         effectiveProvider = 'anthropic';
+                    } else if (specificModel.startsWith('gemini-')) {
+                        effectiveProvider = 'gemini';
                     } else {
                         effectiveProvider = 'openai';
                     }
                 }
-                
+
                 switch (effectiveProvider) {
                     case 'openrouter':
                         providerName = 'OpenRouter';
@@ -157,11 +159,16 @@ export class ChatMessageService {
                         providerName = 'Anthropic';
                         configureCommand = 'superdesign.configureApiKey';
                         break;
+                    case 'gemini':
+                        providerName = 'Google Gemini';
+                        configureCommand = 'superdesign.configureGeminiApiKey';
+                        break;
                     case 'claude-code':
                         providerName = 'Claude Code';
                         configureCommand = 'workbench.action.openSettings';
                         break;
                     case 'openai':
+                    default:
                         providerName = 'OpenAI';
                         configureCommand = 'superdesign.configureOpenAIApiKey';
                         break;

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -139,12 +139,12 @@ export class ChatMessageService {
                 let configureCommand = 'superdesign.configureOpenAIApiKey';
 
                 if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-                    if (specificModel.includes('/')) {
+                    if (this.isGeminiModel(specificModel)) {
+                        effectiveProvider = 'gemini';
+                    } else if (specificModel.includes('/')) {
                         effectiveProvider = 'openrouter';
                     } else if (specificModel.startsWith('claude-')) {
                         effectiveProvider = 'anthropic';
-                    } else if (specificModel.startsWith('gemini-')) {
-                        effectiveProvider = 'gemini';
                     } else {
                         effectiveProvider = 'openai';
                     }
@@ -396,7 +396,7 @@ export class ChatMessageService {
         if (this.currentRequestController) {
             Logger.info('Stopping current chat request');
             this.currentRequestController.abort();
-            
+
             // Send stopped message back to webview
             webview.postMessage({
                 command: 'chatStopped'
@@ -404,6 +404,10 @@ export class ChatMessageService {
         } else {
             Logger.info('No active chat request to stop');
         }
+    }
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
     }
 
     private processClaudeResponse(response: LLMMessage[]): string {

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -95,12 +95,12 @@ export class CustomAgentService implements AgentService {
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
         if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-            if (specificModel.includes('/')) {
+            if (this.isGeminiModel(specificModel)) {
+                effectiveProvider = 'gemini';
+            } else if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
-            } else if (specificModel.startsWith('gemini-')) {
-                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -155,7 +155,7 @@ export class CustomAgentService implements AgentService {
                     apiKey: geminiKey
                 });
 
-                const geminiModel = specificModel || 'gemini-2.5-pro';
+                const geminiModel = this.normalizeGeminiModelId(specificModel) || 'models/gemini-2.5-pro';
                 this.outputChannel.appendLine(`Using Google Gemini model: ${geminiModel}`);
                 return gemini(geminiModel);
             }
@@ -194,12 +194,14 @@ export class CustomAgentService implements AgentService {
         // Determine the actual model name being used
         let modelName: string;
         if (specificModel) {
-            modelName = specificModel;
+            modelName = this.isGeminiModel(specificModel)
+                ? this.normalizeGeminiModelId(specificModel) || specificModel
+                : specificModel;
         } else {
             // Use defaults based on provider
             switch (provider) {
                 case 'gemini':
-                    modelName = 'gemini-2.5-pro';
+                    modelName = 'models/gemini-2.5-pro';
                     break;
                 case 'openrouter':
                     modelName = 'anthropic/claude-3-7-sonnet-20250219';
@@ -967,12 +969,12 @@ I've created the html design, please reveiw and let me know if you need any chan
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
         if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-            if (specificModel.includes('/')) {
+            if (this.isGeminiModel(specificModel)) {
+                effectiveProvider = 'gemini';
+            } else if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
-            } else if (specificModel.startsWith('gemini-')) {
-                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -997,7 +999,7 @@ I've created the html design, please reveiw and let me know if you need any chan
         if (!errorMessage) {
             return false;
         }
-        
+
         const lowerError = errorMessage.toLowerCase();
         return lowerError.includes('api key') ||
                lowerError.includes('authentication') ||
@@ -1007,4 +1009,24 @@ I've created the html design, please reveiw and let me know if you need any chan
                lowerError.includes('api_key_invalid') ||
                lowerError.includes('unauthenticated');
     }
-} 
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
+    }
+
+    private normalizeGeminiModelId(model?: string): string | undefined {
+        if (!model) {
+            return undefined;
+        }
+
+        if (model.startsWith('models/')) {
+            return model;
+        }
+
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+
+        return model;
+    }
+}

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -2,6 +2,7 @@ import { streamText, CoreMessage } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -83,99 +84,113 @@ export class CustomAgentService implements AgentService {
     private getModel() {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
+        const provider = config.get<string>('aiModelProvider', 'openai');
         const openaiUrl = config.get<string>('openaiUrl');
-        
+
         this.outputChannel.appendLine(`Using AI provider: ${provider}`);
         if (specificModel) {
             this.outputChannel.appendLine(`Using specific AI model: ${specificModel}`);
         }
-        
+
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
-        if (specificModel && !(!openaiUrl && provider === 'openai')) {
+        if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
             if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
+            } else if (specificModel.startsWith('gemini-')) {
+                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
         }
-        
+
         switch (effectiveProvider) {
-            case 'openrouter':
+            case 'openrouter': {
                 const openrouterKey = config.get<string>('openrouterApiKey');
                 if (!openrouterKey) {
                     throw new Error('OpenRouter API key not configured. Please run "Configure OpenRouter API Key" command.');
                 }
-                
+
                 this.outputChannel.appendLine(`OpenRouter API key found: ${openrouterKey.substring(0, 12)}...`);
-                
+
                 const openrouter = createOpenRouter({
                     apiKey: openrouterKey
                 });
-                
-                // Use specific model if available, otherwise default to Claude 3.7 Sonnet via OpenRouter
+
                 const openrouterModel = specificModel || 'anthropic/claude-3-7-sonnet-20250219';
                 this.outputChannel.appendLine(`Using OpenRouter model: ${openrouterModel}`);
                 return openrouter.chat(openrouterModel);
-                
-            case 'anthropic':
+            }
+            case 'anthropic': {
                 const anthropicKey = config.get<string>('anthropicApiKey');
                 if (!anthropicKey) {
                     throw new Error('Anthropic API key not configured. Please run "Configure Anthropic API Key" command.');
                 }
-                
+
                 this.outputChannel.appendLine(`Anthropic API key found: ${anthropicKey.substring(0, 12)}...`);
-                
+
                 const anthropic = createAnthropic({
                     apiKey: anthropicKey,
-                    baseURL: "https://anthropic.helicone.ai/v1",
+                    baseURL: 'https://anthropic.helicone.ai/v1',
                     headers: {
-                        "Helicone-Auth": `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
+                        'Helicone-Auth': `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
                     }
                 });
-                
-                // Use specific model if available, otherwise default to claude-3-5-sonnet
+
                 const anthropicModel = specificModel || 'claude-3-5-sonnet-20241022';
                 this.outputChannel.appendLine(`Using Anthropic model: ${anthropicModel}`);
                 return anthropic(anthropicModel);
-                
+            }
+            case 'gemini': {
+                const geminiKey = config.get<string>('geminiApiKey');
+                if (!geminiKey) {
+                    throw new Error('Google Gemini API key not configured. Please run "Configure Gemini API Key" command.');
+                }
+
+                this.outputChannel.appendLine(`Google Gemini API key found: ${geminiKey.substring(0, 7)}...`);
+
+                const gemini = createGoogleGenerativeAI({
+                    apiKey: geminiKey
+                });
+
+                const geminiModel = specificModel || 'gemini-2.5-pro';
+                this.outputChannel.appendLine(`Using Google Gemini model: ${geminiModel}`);
+                return gemini(geminiModel);
+            }
             case 'claude-code':
                 // This case is handled in the query method before reaching this point
                 throw new Error('Claude Code provider should be handled before getModel() is called');
-                
             case 'openai':
-            default:
+            default: {
                 const openaiKey = config.get<string>('openaiApiKey');
-                 const openaiUrl = config.get<string>('openaiUrl');
                 if (!openaiKey) {
                     throw new Error('OpenAI API key not configured. Please run "Configure OpenAI API Key" command.');
                 }
-                
+
                 this.outputChannel.appendLine(`OpenAI API key found: ${openaiKey.substring(0, 7)}...`);
-                
+
                 const openai = createOpenAI({
                     apiKey: openaiKey,
-                    baseURL: openaiUrl ?? "https://oai.helicone.ai/v1",
+                    baseURL: openaiUrl ?? 'https://oai.helicone.ai/v1',
                     headers: {
-                        "Helicone-Auth": `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
+                        'Helicone-Auth': `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
                     }
                 });
-                
-                // Use specific model if available, otherwise default to gpt-4o
-                const openaiModel = specificModel || 'gpt-4o';
+
+                const openaiModel = specificModel || 'gpt-5';
                 this.outputChannel.appendLine(`Using OpenAI model: ${openaiModel}`);
                 return openai(openaiModel);
+            }
         }
     }
 
     private getSystemPrompt(): string {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
-        
+        const provider = config.get<string>('aiModelProvider', 'openai');
+
         // Determine the actual model name being used
         let modelName: string;
         if (specificModel) {
@@ -183,18 +198,21 @@ export class CustomAgentService implements AgentService {
         } else {
             // Use defaults based on provider
             switch (provider) {
-                case 'openai':
-                    modelName = 'gpt-4o';
+                case 'gemini':
+                    modelName = 'gemini-2.5-pro';
                     break;
                 case 'openrouter':
                     modelName = 'anthropic/claude-3-7-sonnet-20250219';
                     break;
+                case 'anthropic':
+                    modelName = 'claude-3-5-sonnet-20241022';
+                    break;
                 case 'claude-code':
                     modelName = 'claude-code';
                     break;
-                case 'anthropic':
+                case 'openai':
                 default:
-                    modelName = 'claude-3-5-sonnet-20241022';
+                    modelName = 'gpt-5';
                     break;
             }
         }
@@ -603,7 +621,7 @@ I've created the html design, please reveiw and let me know if you need any chan
 
         // Check if claude-code is selected and use ClaudeCodeService instead
         const config = vscode.workspace.getConfiguration('superdesign');
-        const aiModelProvider = config.get<string>('aiModelProvider', 'anthropic');
+        const aiModelProvider = config.get<string>('aiModelProvider', 'openai');
         const llmProvider = config.get<string>('llmProvider', 'claude-api');
         
         // If either setting is set to claude-code, use ClaudeCodeService
@@ -943,26 +961,30 @@ I've created the html design, please reveiw and let me know if you need any chan
     hasApiKey(): boolean {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
-        const provider = config.get<string>('aiModelProvider', 'anthropic');
+        const provider = config.get<string>('aiModelProvider', 'openai');
         const openaiUrl = config.get<string>('openaiUrl');
-        
+
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
-        if (specificModel && !(!openaiUrl && provider === 'openai')) {
+        if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
             if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
+            } else if (specificModel.startsWith('gemini-')) {
+                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
         }
-        
+
         switch (effectiveProvider) {
             case 'openrouter':
                 return !!config.get<string>('openrouterApiKey');
             case 'anthropic':
                 return !!config.get<string>('anthropicApiKey');
+            case 'gemini':
+                return !!config.get<string>('geminiApiKey');
             case 'claude-code':
                 return true; // Claude Code doesn't require an API key
             case 'openai':

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -19,7 +19,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
     const { chatHistory, isLoading, sendMessage, clearHistory, setChatHistory } = useChat(vscode);
     const { isFirstTime, isLoading: isCheckingFirstTime, markAsReturningUser, resetFirstTimeUser } = useFirstTimeUser();
     const [inputMessage, setInputMessage] = useState('');
-    const [selectedModel, setSelectedModel] = useState<string>('claude-3-5-sonnet-20241022');
+    const [selectedModel, setSelectedModel] = useState<string>('gpt-5');
     const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
     const [showFullContent, setShowFullContent] = useState<{[key: string]: boolean}>({});
     const [currentContext, setCurrentContext] = useState<{fileName: string; type: string} | null>(null);
@@ -51,15 +51,23 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
             if (message.command === 'currentProviderResponse') {
                 let fallbackModel: string;
                 switch (message.provider) {
-                    case 'openai':
-                        fallbackModel = 'gpt-4o';
-                        break;
                     case 'openrouter':
                         fallbackModel = 'anthropic/claude-3-7-sonnet-20250219';
                         break;
                     case 'anthropic':
-                    default:
                         fallbackModel = 'claude-3-5-sonnet-20241022';
+                        break;
+                    case 'openai':
+                        fallbackModel = 'gpt-5';
+                        break;
+                    case 'gemini':
+                        fallbackModel = 'gemini-2.5-pro';
+                        break;
+                    case 'claude-code':
+                        fallbackModel = 'claude-code';
+                        break;
+                    default:
+                        fallbackModel = 'gpt-5';
                         break;
                 }
                 setSelectedModel(message.model || fallbackModel);

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -40,12 +40,25 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
         );
     };
 
+    const normalizeGeminiModelId = (model?: string) => {
+        if (!model) {
+            return model;
+        }
+        if (model.startsWith('models/')) {
+            return model;
+        }
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+        return model;
+    };
+
     // Request current provider on mount
     useEffect(() => {
         vscode.postMessage({
             command: 'getCurrentProvider'
         });
-        
+
         const handleMessage = (event: MessageEvent) => {
             const message = event.data;
             if (message.command === 'currentProviderResponse') {
@@ -61,7 +74,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                         fallbackModel = 'gpt-5';
                         break;
                     case 'gemini':
-                        fallbackModel = 'gemini-2.5-pro';
+                        fallbackModel = 'models/gemini-2.5-pro';
                         break;
                     case 'claude-code':
                         fallbackModel = 'claude-code';
@@ -70,9 +83,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                         fallbackModel = 'gpt-5';
                         break;
                 }
-                setSelectedModel(message.model || fallbackModel);
+                const normalizedModel = normalizeGeminiModelId(message.model);
+                setSelectedModel(normalizedModel || fallbackModel);
             } else if (message.command === 'providerChanged') {
-                setSelectedModel(message.model);
+                const normalizedModel = normalizeGeminiModelId(message.model);
+                setSelectedModel(normalizedModel || message.model);
             }
         };
         

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -37,8 +37,8 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         // Google Gemini (direct)
-        { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google Gemini', category: 'Balanced' },
-        { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google Gemini', category: 'Fast' },
+        { id: 'models/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google Gemini', category: 'Balanced' },
+        { id: 'models/gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google Gemini', category: 'Fast' },
         // OpenRouter models
         { id: 'anthropic/claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet (OpenRouter)', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
         { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro (OpenRouter)', provider: 'OpenRouter (Google)', category: 'Balanced' },

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -22,44 +22,41 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
     const modalRef = useRef<HTMLDivElement>(null);
 
     const models: ModelOption[] = [
-        // Anthropic
+        // OpenAI (direct)
+        { id: 'gpt-5', name: 'GPT-5', provider: 'OpenAI', category: 'Premium' },
+        { id: 'gpt-5-codex', name: 'GPT-5 Codex', provider: 'OpenAI', category: 'Coding' },
+        { id: 'gpt-5-mini', name: 'GPT-5 Mini', provider: 'OpenAI', category: 'Fast' },
+        { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
+        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' },
+        { id: 'gpt-4.1-nano', name: 'GPT-4.1 Nano', provider: 'OpenAI', category: 'Lightweight' },
+        { id: 'gpt-4o', name: 'GPT-4o', provider: 'OpenAI', category: 'Multimodal' },
+        { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'OpenAI', category: 'Fast' },
+        // Anthropic (direct)
         { id: 'claude-4-opus-20250514', name: 'Claude 4 Opus', provider: 'Anthropic', category: 'Premium' },
         { id: 'claude-4-sonnet-20250514', name: 'Claude 4 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
-        // Google (OpenRouter)
-        { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'OpenRouter (Google)', category: 'Balanced' },
-        // Meta (OpenRouter)
+        // Google Gemini (direct)
+        { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google Gemini', category: 'Balanced' },
+        { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google Gemini', category: 'Fast' },
+        // OpenRouter models
+        { id: 'anthropic/claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet (OpenRouter)', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
+        { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro (OpenRouter)', provider: 'OpenRouter (Google)', category: 'Balanced' },
         { id: 'meta-llama/llama-4-maverick-17b-128e-instruct', name: 'Llama 4 Maverick 17B', provider: 'OpenRouter (Meta)', category: 'Balanced' },
-        // DeepSeek (OpenRouter)
-        { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
-        // Mistral (OpenRouter)
+        { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'OpenRouter (DeepSeek)', category: 'Reasoning' },
         { id: 'mistralai/mistral-small-3.2-24b-instruct-2506', name: 'Mistral Small 3.2 24B', provider: 'OpenRouter (Mistral)', category: 'Balanced' },
-        // xAI (OpenRouter)
         { id: 'x-ai/grok-3', name: 'Grok 3', provider: 'OpenRouter (xAI)', category: 'Balanced' },
-        // Qwen (OpenRouter)
         { id: 'qwen/qwen3-235b-a22b-04-28', name: 'Qwen3 235B', provider: 'OpenRouter (Qwen)', category: 'Balanced' },
-        // Perplexity (OpenRouter)
-        { id: 'perplexity/sonar-reasoning-pro', name: 'Sonar Reasoning Pro', provider: 'OpenRouter (Perplexity)', category: 'Balanced' },
-        // Microsoft (OpenRouter)
-        { id: 'microsoft/phi-4-reasoning-plus-04-30', name: 'Phi-4 Reasoning Plus', provider: 'OpenRouter (Microsoft)', category: 'Balanced' },
-        // NVIDIA (OpenRouter)
+        { id: 'perplexity/sonar-reasoning-pro', name: 'Sonar Reasoning Pro', provider: 'OpenRouter (Perplexity)', category: 'Reasoning' },
+        { id: 'microsoft/phi-4-reasoning-plus-04-30', name: 'Phi-4 Reasoning Plus', provider: 'OpenRouter (Microsoft)', category: 'Reasoning' },
         { id: 'nvidia/llama-3.3-nemotron-super-49b-v1', name: 'Llama 3.3 Nemotron Super 49B', provider: 'OpenRouter (NVIDIA)', category: 'Balanced' },
-        // Cohere (OpenRouter)
         { id: 'cohere/command-a-03-2025', name: 'Command A', provider: 'OpenRouter (Cohere)', category: 'Balanced' },
-        // Amazon (OpenRouter)
         { id: 'amazon/nova-pro-v1', name: 'Nova Pro', provider: 'OpenRouter (Amazon)', category: 'Balanced' },
-        // Inflection (OpenRouter)
         { id: 'inflection/inflection-3-productivity', name: 'Inflection 3 Productivity', provider: 'OpenRouter (Inflection)', category: 'Balanced' },
-        // Reka (OpenRouter)
-        { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
-        // Additional OpenRouter models
-        { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1', provider: 'OpenRouter (xAI)', category: 'Fast' },
-        { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
-        { id: 'deepseek/deepseek-chat-v3.1:free', name: 'DeepSeek Chat V3.1 Free', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
-        // Existing OpenAI (direct)
-        { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
-        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
+        { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Fast' },
+        { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1', provider: 'OpenRouter (xAI)', category: 'Coding' },
+        { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4 (OpenRouter)', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
+        { id: 'deepseek/deepseek-chat-v3.1:free', name: 'DeepSeek Chat V3.1 Free', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' }
     ];
 
     const filteredModels = models.filter(model =>


### PR DESCRIPTION
## Summary
- restore OpenRouter provider wiring and API key configuration while keeping GPT-5 as the default OpenAI model
- add direct Google Gemini support alongside existing providers with updated backend routing and error handling
- expand the chat UI model selector and provider metadata to list GPT-5 options plus Anthropic and OpenRouter choices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d665c25d3883299092d057558e8a5e