### PR TITLE
Normalize Gemini model identifiers

### DIFF
--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -99,6 +99,11 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         const config = vscode.workspace.getConfiguration('superdesign');
         const currentProvider = config.get<string>('aiModelProvider', 'openai');
         const currentModel = config.get<string>('aiModel');
+        const normalizedModel = this.normalizeGeminiModelId(currentModel);
+
+        if (normalizedModel && normalizedModel !== currentModel) {
+            await config.update('aiModel', normalizedModel, vscode.ConfigurationTarget.Global);
+        }
 
         // If no specific model is set, use defaults
         let defaultModel: string;
@@ -110,7 +115,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                 defaultModel = 'claude-3-5-sonnet-20241022';
                 break;
             case 'gemini':
-                defaultModel = 'gemini-2.5-pro';
+                defaultModel = 'models/gemini-2.5-pro';
                 break;
             case 'claude-code':
                 defaultModel = 'claude-code';
@@ -124,46 +129,48 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         webview.postMessage({
             command: 'currentProviderResponse',
             provider: currentProvider,
-            model: currentModel || defaultModel
+            model: normalizedModel || defaultModel
         });
     }
 
     private async handleChangeProvider(model: string, webview: vscode.Webview) {
         try {
             const config = vscode.workspace.getConfiguration('superdesign');
-            
+
+            const normalizedModel = this.normalizeGeminiModelId(model) || model;
+
             // Determine provider and API key based on model
             let provider: string;
             let apiKeyKey: string;
             let configureCommand: string;
             let displayName: string;
 
-            if (model.includes('/')) {
-                provider = 'openrouter';
-                apiKeyKey = 'openrouterApiKey';
-                configureCommand = 'superdesign.configureOpenRouterApiKey';
-                displayName = `OpenRouter (${this.getModelDisplayName(model)})`;
-            } else if (model.startsWith('claude-')) {
-                provider = 'anthropic';
-                apiKeyKey = 'anthropicApiKey';
-                configureCommand = 'superdesign.configureApiKey';
-                displayName = `Anthropic (${this.getModelDisplayName(model)})`;
-            } else if (model.startsWith('gemini-')) {
+            if (this.isGeminiModel(normalizedModel)) {
                 provider = 'gemini';
                 apiKeyKey = 'geminiApiKey';
                 configureCommand = 'superdesign.configureGeminiApiKey';
-                displayName = `Google Gemini (${this.getModelDisplayName(model)})`;
+                displayName = `Google Gemini (${this.getModelDisplayName(normalizedModel)})`;
+            } else if (normalizedModel.includes('/')) {
+                provider = 'openrouter';
+                apiKeyKey = 'openrouterApiKey';
+                configureCommand = 'superdesign.configureOpenRouterApiKey';
+                displayName = `OpenRouter (${this.getModelDisplayName(normalizedModel)})`;
+            } else if (normalizedModel.startsWith('claude-')) {
+                provider = 'anthropic';
+                apiKeyKey = 'anthropicApiKey';
+                configureCommand = 'superdesign.configureApiKey';
+                displayName = `Anthropic (${this.getModelDisplayName(normalizedModel)})`;
             } else {
                 provider = 'openai';
                 apiKeyKey = 'openaiApiKey';
                 configureCommand = 'superdesign.configureOpenAIApiKey';
-                displayName = `OpenAI (${this.getModelDisplayName(model)})`;
+                displayName = `OpenAI (${this.getModelDisplayName(normalizedModel)})`;
             }
-            
+
             // Update both provider and specific model
             await config.update('aiModelProvider', provider, vscode.ConfigurationTarget.Global);
-            await config.update('aiModel', model, vscode.ConfigurationTarget.Global);
-            
+            await config.update('aiModel', normalizedModel, vscode.ConfigurationTarget.Global);
+
             // Check if the API key is configured for the selected provider
             const apiKey = config.get<string>(apiKeyKey);
             
@@ -183,7 +190,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             webview.postMessage({
                 command: 'providerChanged',
                 provider: provider,
-                model: model
+                model: normalizedModel
             });
 
         } catch (error) {
@@ -209,7 +216,9 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
             // Gemini models
             'gemini-2.5-pro': 'Gemini 2.5 Pro',
+            'models/gemini-2.5-pro': 'Gemini 2.5 Pro',
             'gemini-2.5-flash': 'Gemini 2.5 Flash',
+            'models/gemini-2.5-flash': 'Gemini 2.5 Flash',
             // OpenRouter models
             'anthropic/claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet (OpenRouter)',
             'google/gemini-2.5-pro': 'Gemini 2.5 Pro (OpenRouter)',
@@ -231,5 +240,25 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         };
 
         return modelNames[model] || model;
+    }
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
+    }
+
+    private normalizeGeminiModelId(model?: string): string | undefined {
+        if (!model) {
+            return undefined;
+        }
+
+        if (model.startsWith('models/')) {
+            return model;
+        }
+
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+
+        return model;
     }
 }

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -139,12 +139,12 @@ export class ChatMessageService {
                 let configureCommand = 'superdesign.configureOpenAIApiKey';
 
                 if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-                    if (specificModel.includes('/')) {
+                    if (this.isGeminiModel(specificModel)) {
+                        effectiveProvider = 'gemini';
+                    } else if (specificModel.includes('/')) {
                         effectiveProvider = 'openrouter';
                     } else if (specificModel.startsWith('claude-')) {
                         effectiveProvider = 'anthropic';
-                    } else if (specificModel.startsWith('gemini-')) {
-                        effectiveProvider = 'gemini';
                     } else {
                         effectiveProvider = 'openai';
                     }
@@ -396,7 +396,7 @@ export class ChatMessageService {
         if (this.currentRequestController) {
             Logger.info('Stopping current chat request');
             this.currentRequestController.abort();
-            
+
             // Send stopped message back to webview
             webview.postMessage({
                 command: 'chatStopped'
@@ -404,6 +404,10 @@ export class ChatMessageService {
         } else {
             Logger.info('No active chat request to stop');
         }
+    }
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
     }
 
     private processClaudeResponse(response: LLMMessage[]): string {

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -95,12 +95,12 @@ export class CustomAgentService implements AgentService {
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
         if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-            if (specificModel.includes('/')) {
+            if (this.isGeminiModel(specificModel)) {
+                effectiveProvider = 'gemini';
+            } else if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
-            } else if (specificModel.startsWith('gemini-')) {
-                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -155,7 +155,7 @@ export class CustomAgentService implements AgentService {
                     apiKey: geminiKey
                 });
 
-                const geminiModel = specificModel || 'gemini-2.5-pro';
+                const geminiModel = this.normalizeGeminiModelId(specificModel) || 'models/gemini-2.5-pro';
                 this.outputChannel.appendLine(`Using Google Gemini model: ${geminiModel}`);
                 return gemini(geminiModel);
             }
@@ -194,12 +194,14 @@ export class CustomAgentService implements AgentService {
         // Determine the actual model name being used
         let modelName: string;
         if (specificModel) {
-            modelName = specificModel;
+            modelName = this.isGeminiModel(specificModel)
+                ? this.normalizeGeminiModelId(specificModel) || specificModel
+                : specificModel;
         } else {
             // Use defaults based on provider
             switch (provider) {
                 case 'gemini':
-                    modelName = 'gemini-2.5-pro';
+                    modelName = 'models/gemini-2.5-pro';
                     break;
                 case 'openrouter':
                     modelName = 'anthropic/claude-3-7-sonnet-20250219';
@@ -967,12 +969,12 @@ I've created the html design, please reveiw and let me know if you need any chan
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
         if (specificModel && provider !== 'claude-code' && !(!openaiUrl && provider === 'openai')) {
-            if (specificModel.includes('/')) {
+            if (this.isGeminiModel(specificModel)) {
+                effectiveProvider = 'gemini';
+            } else if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
-            } else if (specificModel.startsWith('gemini-')) {
-                effectiveProvider = 'gemini';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -997,7 +999,7 @@ I've created the html design, please reveiw and let me know if you need any chan
         if (!errorMessage) {
             return false;
         }
-        
+
         const lowerError = errorMessage.toLowerCase();
         return lowerError.includes('api key') ||
                lowerError.includes('authentication') ||
@@ -1007,4 +1009,24 @@ I've created the html design, please reveiw and let me know if you need any chan
                lowerError.includes('api_key_invalid') ||
                lowerError.includes('unauthenticated');
     }
-} 
+
+    private isGeminiModel(model?: string): boolean {
+        return !!model && (model.startsWith('gemini-') || model.startsWith('models/gemini-'));
+    }
+
+    private normalizeGeminiModelId(model?: string): string | undefined {
+        if (!model) {
+            return undefined;
+        }
+
+        if (model.startsWith('models/')) {
+            return model;
+        }
+
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+
+        return model;
+    }
+}

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -40,12 +40,25 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
         );
     };
 
+    const normalizeGeminiModelId = (model?: string) => {
+        if (!model) {
+            return model;
+        }
+        if (model.startsWith('models/')) {
+            return model;
+        }
+        if (model.startsWith('gemini-')) {
+            return `models/${model}`;
+        }
+        return model;
+    };
+
     // Request current provider on mount
     useEffect(() => {
         vscode.postMessage({
             command: 'getCurrentProvider'
         });
-        
+
         const handleMessage = (event: MessageEvent) => {
             const message = event.data;
             if (message.command === 'currentProviderResponse') {
@@ -61,7 +74,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                         fallbackModel = 'gpt-5';
                         break;
                     case 'gemini':
-                        fallbackModel = 'gemini-2.5-pro';
+                        fallbackModel = 'models/gemini-2.5-pro';
                         break;
                     case 'claude-code':
                         fallbackModel = 'claude-code';
@@ -70,9 +83,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                         fallbackModel = 'gpt-5';
                         break;
                 }
-                setSelectedModel(message.model || fallbackModel);
+                const normalizedModel = normalizeGeminiModelId(message.model);
+                setSelectedModel(normalizedModel || fallbackModel);
             } else if (message.command === 'providerChanged') {
-                setSelectedModel(message.model);
+                const normalizedModel = normalizeGeminiModelId(message.model);
+                setSelectedModel(normalizedModel || message.model);
             }
         };
         

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -37,8 +37,8 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         { id: 'claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', provider: 'Anthropic', category: 'Balanced' },
         // Google Gemini (direct)
-        { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google Gemini', category: 'Balanced' },
-        { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google Gemini', category: 'Fast' },
+        { id: 'models/gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google Gemini', category: 'Balanced' },
+        { id: 'models/gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google Gemini', category: 'Fast' },
         // OpenRouter models
         { id: 'anthropic/claude-3-7-sonnet-20250219', name: 'Claude 3.7 Sonnet (OpenRouter)', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
         { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro (OpenRouter)', provider: 'OpenRouter (Google)', category: 'Balanced' },


### PR DESCRIPTION
## Summary
- normalize Gemini model IDs before storing or sending them so Google calls use the models/ prefix
- update the VS Code webview and model selector to surface the prefixed Gemini identifiers by default
- ensure Gemini provider detection works with both legacy and normalized IDs across the extension

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d753f821b883298f6512ffbb79c0c9